### PR TITLE
Fix chrome javascript error by upgrading angular version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
     "tests"
   ],
   "dependencies": {
-    "angular": "1.5.7",
+    "angular": "1.7.9",
     "angular-local-storage": "^0.2.7",
     "bootstrap": "~3.2.0",
     "angular-route": "^1.5.5"


### PR DESCRIPTION
Chrome now throws a nasty javascript error with the vanilla install.

Updating to angular 1.7.9 fixes it.

